### PR TITLE
Avoid state problem with take turn

### DIFF
--- a/lib/battleship/game.rb
+++ b/lib/battleship/game.rb
@@ -17,7 +17,7 @@ module Battleship
       player, opponent, board = @state[@turn]
       @turn = -(@turn - 1)
 
-      result = board.try(player.take_turn(board.report, board.ships_remaining))
+      result = board.try(player.take_turn(board.report, board.ships_remaining).dup)
       @winner = player if board.sunk?
       
       result


### PR DESCRIPTION
If you don't duplicate the array of coordinates as it is passed to take turn, and the player returns the same object reference, then the game does not remember the state of previous shots (at least the misses).

No test, sorry :( but you can replicate the problem with a player that sets up @pos = [] in new_game or initilaize or wherever and then:

def take_turn(*args)
  @pos[0] = rand(10)
  @pos[1] = rand(10)
  @pos
end
