### PR TITLE
Using to_sym to make sure method list is symbols only

### DIFF
--- a/lib/battleship/util.rb
+++ b/lib/battleship/util.rb
@@ -9,7 +9,8 @@ module Battleship
         select { |sym| sym.to_s =~ /Player$/ }.
         map    { |sym| Module.const_get(sym) }.
         select { |klass|
-          (klass.instance_methods & PLAYER_METHODS) == PLAYER_METHODS
+          methods = klass.instance_methods.collect { |m| m.to_sym }
+          (methods & PLAYER_METHODS) == PLAYER_METHODS
         }
     end
 


### PR DESCRIPTION
_Class#instance_methods_ seems to return a list of strings in Ruby1.9.2p290. I added a call to _to_sym_ to make sure that the comparison with _PLAYER_METHODS_ works.
